### PR TITLE
Change logic for updating state of story on label change (and one additional change)

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,7 @@ const STORY_STATES = {
 const LABEL_STORY_MAP = {
   'needs more work': STORY_STATES.IN_DEVELOPMENT,
   'ready for review': STORY_STATES.READY_FOR_REVIEW,
+  'ready to merge': STORY_STATES.COMPLETED,
 };
 
 class ClubhouseClient {

--- a/index.js
+++ b/index.js
@@ -12,7 +12,6 @@ const STORY_STATES = {
 const LABEL_STORY_MAP = {
   'needs more work': STORY_STATES.IN_DEVELOPMENT,
   'ready for review': STORY_STATES.READY_FOR_REVIEW,
-  'ready to merge': STORY_STATES.COMPLETED,
 };
 
 class ClubhouseClient {


### PR DESCRIPTION
### Changes
**Main change**:
Now, the story state is changed only when a new label is applied. Mostly, doing this so that changing the labels on a PR does not update the state of the story multiple times. Also think this makes the
logic easier to reason about.

We shouldn't lose anything from not updating the story to In Development when the "ready for review" label is removed, because the "needs more work" label is always expected to be added when a PR that was previously ready for review requires further development.

**Additional change**:
Now moving a story to Completed, when the corresponding PR is marked "ready to merge". This may no be a good change, since technically a story isn't completed until a PR is deployed. So, happy to revert it.

### Testing
No testing done.